### PR TITLE
Use pkgconfig-depends for fuse dependency

### DIFF
--- a/HFuse.cabal
+++ b/HFuse.cabal
@@ -20,23 +20,19 @@ flag developer
 
 Library
   Build-Depends:          base >= 4 && < 5, unix, bytestring
+  Pkgconfig-Depends:      fuse
   Exposed-Modules:        System.Fuse
   Extensions:             ForeignFunctionInterface ScopedTypeVariables EmptyDataDecls
-  Includes:               dirent.h, fuse.h, fcntl.h
+  Includes:               dirent.h, fcntl.h
   Include-Dirs:           /usr/include, /usr/local/include, .
   if os(darwin)
       CC-Options:           "-DMACFUSE"
-      Include-Dirs:           /usr/local/include/osxfuse
   else
       if os(freebsd)
          Includes:           sys/param.h, sys/mount.h
          CC-Options:           "-Df_namelen=f_namemax"
       else
          Includes:               sys/statfs.h
-
-  Extra-Libraries:        fuse
-  Extra-Lib-Dirs:         /usr/local/lib
-  CC-Options:             "-D_FILE_OFFSET_BITS=64"
 
 executable HelloFS
   if flag(developer)


### PR DESCRIPTION
Fixes build failure on OS X; details in the commit comment.

I'm pretty new to Haskell so there's a decent chance I'm doing something dumb with this, but the [Cabal docs](https://www.haskell.org/cabal/release/cabal-latest/doc/users-guide/developing-packages.html#package-properties) say pkgconfig-depends is preferable so I ran with it.

I'm a little nervous about the impact of this on other platforms (Linux, FreeBSD, OS X with MacFUSE instead of OSXFUSE), since I haven't tested these. In theory, all of those should have their FUSE registered with pkg-config, so it *should* be fine... but testing this on another machine or two would probably be a good idea.