### PR TITLE
OSXFuse compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+.virtualenv
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config

--- a/HFuse.cabal
+++ b/HFuse.cabal
@@ -26,6 +26,7 @@ Library
   Include-Dirs:           /usr/include, /usr/local/include, .
   if os(darwin)
       CC-Options:           "-DMACFUSE"
+      CC-Options:           "-DFUSE_USE_VERSION=26"
       Include-Dirs:           /usr/local/include/osxfuse
   else
       if os(freebsd)
@@ -34,7 +35,10 @@ Library
       else
          Includes:               sys/statfs.h
 
-  Extra-Libraries:        fuse
+  if os(darwin)
+      Extra-Libraries:        osxfuse
+  else
+      Extra-Libraries:        fuse
   Extra-Lib-Dirs:         /usr/local/lib
   CC-Options:             "-D_FILE_OFFSET_BITS=64"
   Default-Language:       Haskell2010

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ This library is the Haskell binding to this library.
 - This now works for base 4.6+
 - Added build options support for FreeBSD (contribution by https://github.com/pesco)
 - MacFUSE should also work (https://github.com/mwotton/hfuse)
+- [OSXFuse](https://osxfuse.github.io/) also works (https://github.com/edyu/hfuse)
 
 ## Installation
 
 All of the usual methods for installation will be supported.
+For Mac OS X, you must install [OSXFuse](https://osxfuse.github.io/) first.
 
 **Installation via Hackage**
 
@@ -31,7 +33,7 @@ Can either be handled via [Hackage](http://hackage.haskell.org/packages/search?t
 
 ```
 cabal unpack hfuse
-cd HFuse-0.2.4.3
+cd HFuse-0.2.4.4
 cabal sandbox init
 cabal install --only-dependencies
 cabal install -fdeveloper


### PR DESCRIPTION
These are the changes needed for HFuse to compile and install properly on Mac OS X using OSXFuse (successor to MacFuse):

    * The library is called osxfuse instead of fuse
    * Add FUSE_USE_VERSION=26 for the latest API level (needed to build on OS X)